### PR TITLE
Fix iteration over installed Xcode paths

### DIFF
--- a/templates/scripts/install-xcode.bash
+++ b/templates/scripts/install-xcode.bash
@@ -44,11 +44,14 @@ function install_xcode() {
 	sudo DevToolsSecurity -enable
 	sudo dseditgroup -o edit -t group -a staff _developer
 
-	declare -ra installed_xcode_paths="$(get_paths_to_installed_xcode_versions)"
+       declare -a installed_xcode_paths=()
+       while IFS= read -r path; do
+               installed_xcode_paths+=("${path}")
+       done < <(get_paths_to_installed_xcode_versions)
 
-	for xcode_path in "${installed_xcode_paths[@]}"; do
-		declare xcode_version
-		xcode_version="$(get_xcode_version_at_path "$xcode_path")"
+       for xcode_path in "${installed_xcode_paths[@]}"; do
+               declare xcode_version
+               xcode_version="$(get_xcode_version_at_path "$xcode_path")"
 		sudo xcode-select --switch "$xcode_path"
 		sudo xcodebuild -license accept
 

--- a/templates/scripts/lib/xcode-utils.bash
+++ b/templates/scripts/lib/xcode-utils.bash
@@ -93,25 +93,30 @@ function get_xcode_version_at_path() {
 }
 
 function get_path_to_xcode_version() {
-	declare -r xcode_version="$(normalize_xcode_version "$1")"
+        declare -r xcode_version="$(normalize_xcode_version "$1")"
 
-	for installed_xcode_path in $(get_paths_to_installed_xcode_versions); do
-		declare installed_xcode_version
-		installed_xcode_version="$(get_xcode_version_at_path "${installed_xcode_path}")"
+        declare -a installed_xcode_paths=()
+        while IFS= read -r path; do
+                installed_xcode_paths+=("${path}")
+        done < <(get_paths_to_installed_xcode_versions)
 
-		if [[ "${installed_xcode_version}" == "${xcode_version}" ]]; then
-			echo "${installed_xcode_path}"
-			return
-		fi
-	done
+        for installed_xcode_path in "${installed_xcode_paths[@]}"; do
+                declare installed_xcode_version
+                installed_xcode_version="$(get_xcode_version_at_path "${installed_xcode_path}")"
+
+                if [[ "${installed_xcode_version}" == "${xcode_version}" ]]; then
+                        echo "${installed_xcode_path}"
+                        return
+                fi
+        done
 }
 
 function get_paths_to_installed_xcode_versions() {
-	declare -a installed_xcode_paths
-	while read -r xcode_path; do
-		installed_xcode_paths+=("${xcode_path}")
-	done < <(
-		/usr/bin/mdfind -onlyin "/" "kMDItemCFBundleIdentifier='com.apple.dt.Xcode'"
-	)
-	echo "${installed_xcode_paths[@]}"
+        declare -a installed_xcode_paths
+        while read -r xcode_path; do
+                installed_xcode_paths+=("${xcode_path}")
+        done < <(
+                /usr/bin/mdfind -onlyin "/" "kMDItemCFBundleIdentifier='com.apple.dt.Xcode'"
+        )
+        printf '%s\n' "${installed_xcode_paths[@]}"
 }

--- a/templates/scripts/tests/test_xcode-utils.bash
+++ b/templates/scripts/tests/test_xcode-utils.bash
@@ -36,34 +36,46 @@ function test_get_selected_xcode_version() {
 }
 
 function test_get_xcode_version_at_path() {
-	local all_ok=0
-	for xcode_path in $(get_paths_to_installed_xcode_versions); do
-		local version
-		version=$(get_xcode_version_at_path "$xcode_path")
-		[[ -n "$version" ]] || all_ok=1
-	done
-	return $all_ok
+       local all_ok=0
+       local xcode_paths=()
+       while IFS= read -r path; do
+               xcode_paths+=("${path}")
+       done < <(get_paths_to_installed_xcode_versions)
+       for xcode_path in "${xcode_paths[@]}"; do
+               local version
+               version=$(get_xcode_version_at_path "$xcode_path")
+               [[ -n "$version" ]] || all_ok=1
+       done
+       return $all_ok
 }
 
 function test_get_path_to_xcode_version() {
-	local all_ok=0
-	for xcode_path in $(get_paths_to_installed_xcode_versions); do
-		local version found_path
-		version=$(get_xcode_version_at_path "$xcode_path")
-		found_path=$(get_path_to_xcode_version "$version")
-		[[ "$found_path" == "$xcode_path" ]] || all_ok=1
-	done
-	return $all_ok
+       local all_ok=0
+       local xcode_paths=()
+       while IFS= read -r path; do
+               xcode_paths+=("${path}")
+       done < <(get_paths_to_installed_xcode_versions)
+       for xcode_path in "${xcode_paths[@]}"; do
+               local version found_path
+               version=$(get_xcode_version_at_path "$xcode_path")
+               found_path=$(get_path_to_xcode_version "$version")
+               [[ "$found_path" == "$xcode_path" ]] || all_ok=1
+       done
+       return $all_ok
 }
 
 function test_check_xcode_version_is_installed() {
-	local all_ok=0
-	for xcode_path in $(get_paths_to_installed_xcode_versions); do
-		local version
-		version=$(get_xcode_version_at_path "$xcode_path")
-		check_xcode_version_is_installed "$version" || all_ok=1
-	done
-	return $all_ok
+       local all_ok=0
+       local xcode_paths=()
+       while IFS= read -r path; do
+               xcode_paths+=("${path}")
+       done < <(get_paths_to_installed_xcode_versions)
+       for xcode_path in "${xcode_paths[@]}"; do
+               local version
+               version=$(get_xcode_version_at_path "$xcode_path")
+               check_xcode_version_is_installed "$version" || all_ok=1
+       done
+       return $all_ok
 }
 
 function test_check_xcode_version_is_selected() {


### PR DESCRIPTION
## Summary
- handle spaces when enumerating installed Xcode paths
- avoid mapfile (not available on macOS bash)
- adjust tests to use new helpers

## Testing
- `bash templates/scripts/tests/test_xcode-utils.bash` *(fails: mdfind not found)*

------
https://chatgpt.com/codex/tasks/task_e_684192d0cfe48331b6c696c077bfa522